### PR TITLE
feat: Add validation for self_target and fixedValue (x2)

### DIFF
--- a/automation_common/validation/models.py
+++ b/automation_common/validation/models.py
@@ -215,6 +215,7 @@ class IEffect(Effect):
     stacking: Optional[bool]
     save_as: Optional[str255]
     parent: Optional[str255]
+    self_target: Optional[bool]
 
     _save_as_identifier = validator("save_as", allow_reuse=True)(str_is_identifier)
 
@@ -234,6 +235,7 @@ class Roll(Effect):
     cantripScale: Optional[bool]
     hidden: Optional[bool]
     displayName: Optional[str255]
+    fixedValue: Optional[bool]
 
 
 # --- text ---
@@ -270,6 +272,7 @@ class UseCounter(Effect):
     amount: IntExpression
     allowOverflow: Optional[bool]
     errorBehaviour: Optional[Literal["warn", "raise", "ignore"]]
+    fixedValue: Optional[bool]
 
 
 # --- spell ---

--- a/automation_common/validation/models.py
+++ b/automation_common/validation/models.py
@@ -136,6 +136,7 @@ class Damage(Effect):
     overheal: Optional[bool]
     higher: Optional[HigherLevels]
     cantripScale: Optional[bool]
+    fixedValue: Optional[bool]
 
 
 # --- temphp ---

--- a/automation_common/validation/models.py
+++ b/automation_common/validation/models.py
@@ -216,7 +216,7 @@ class IEffect(Effect):
     stacking: Optional[bool]
     save_as: Optional[str255]
     parent: Optional[str255]
-    self_target: Optional[bool]
+    target_self: Optional[bool]
 
     _save_as_identifier = validator("save_as", allow_reuse=True)(str_is_identifier)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="avrae-automation-common",
-    version="4.1.6",
+    version="4.1.7",
     author="Andrew Zhu",
     author_email="andrew@zhu.codes",
     description="Common automation utilities for Avrae",


### PR DESCRIPTION
### Summary
Adds validation for self_target for target effects, allowing ieffects to target the caster even under another target branch, and fixedValue for roll and use counter effects, causing them to ignore argument/effect changes (but not `-i`)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
