### PR TITLE
feat(ieffect): add tick_on_caster

### DIFF
--- a/automation_common/validation/models.py
+++ b/automation_common/validation/models.py
@@ -218,6 +218,7 @@ class IEffect(Effect):
     save_as: Optional[str255]
     parent: Optional[str255]
     target_self: Optional[bool]
+    tick_on_caster: Optional[bool]
 
     _save_as_identifier = validator("save_as", allow_reuse=True)(str_is_identifier)
 


### PR DESCRIPTION
### Summary
Allows IEffects to tick on the caster's turn, rather than the target's, without having to use a parent effect.

