### PR TITLE
Update Save type to allow multiple saves

### DIFF
--- a/automation_common/validation/models.py
+++ b/automation_common/validation/models.py
@@ -120,9 +120,12 @@ class Attack(Effect):
 
 
 # --- save ---
+SaveType = Literal["str", "dex", "con", "int", "wis", "cha"]
+
+
 class Save(Effect):
     type: Literal["save"]
-    stat: Literal["str", "dex", "con", "int", "wis", "cha"]
+    stat: Union[conlist(SaveType, min_items=1), SaveType]
     fail: ValidatedAutomation
     success: ValidatedAutomation
     dc: Optional[IntExpression]


### PR DESCRIPTION
Part of a larger scope change to allow a list of saves in a Save Effect.